### PR TITLE
Validation of the response of a request to the well known endpoint.

### DIFF
--- a/TDConnectIosSdk.podspec
+++ b/TDConnectIosSdk.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |s|
   s.license      = 'Apache License, Version 2.0'
   s.author       = "Telenor Digital"
   s.source       = { :git => 'https://github.com/telenordigital/connect-ios-sdk.git', :tag => s.version }
-  s.platform     = :ios, 8.0
+  s.platform     = :ios, 9.0
   s.source_files = 'TDConnectIosSdk/*.{swift,h,m}', 'TDConnectIosSdk/libs/curl/include/curl/*.{h}'
   s.vendored_libraries = 'TDConnectIosSdk/libs/curl/lib/libcurl.a'
   s.libraries    = 'z'

--- a/TDConnectIosSdk.podspec
+++ b/TDConnectIosSdk.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |s|
   s.license      = 'Apache License, Version 2.0'
   s.author       = "Telenor Digital"
   s.source       = { :git => 'https://github.com/telenordigital/connect-ios-sdk.git', :tag => s.version }
-  s.platform     = :ios, 9.0
+  s.platform     = :ios, 8.0
   s.source_files = 'TDConnectIosSdk/*.{swift,h,m}', 'TDConnectIosSdk/libs/curl/include/curl/*.{h}'
   s.vendored_libraries = 'TDConnectIosSdk/libs/curl/lib/libcurl.a'
   s.libraries    = 'z'

--- a/TDConnectIosSdk/ForcedHEManager.h
+++ b/TDConnectIosSdk/ForcedHEManager.h
@@ -4,11 +4,12 @@
 #import <Foundation/Foundation.h>
 
 @interface ForcedHEManager : NSObject
-+ (bool) isWifiEnabled;
-+ (bool) isCellularEnabled;
-+ (bool) shouldFetchThroughCellular:(NSString *)url;
++ (bool)isWifiEnabled;
++ (bool)isCellularEnabled;
++ (bool)shouldFetchThroughCellular:(NSString *)url;
 + (NSDictionary *) openUrlThroughCellular:(NSString *)url;
-+ (void) initForcedHE:(NSString *)wellKnownConfigurationEndpoint;
++ (void)initForcedHE:(NSString *)wellKnownConfigurationEndpoint;
++ (void)fetchWellknown:(NSString *)wellKnownConfigurationEndpoint completion:(void(^)(BOOL))completionHandler;
 @end
 
 #endif

--- a/TDConnectIosSdk/ForcedHEManager.m
+++ b/TDConnectIosSdk/ForcedHEManager.m
@@ -15,29 +15,43 @@ int MAX_REDIRECTS_TO_FOLLOW_FOR_HE = 5;
 
 static NSSet *_urlsForHE = nil;
 
-+ (void) initForcedHE:(NSString *)wellKnownConfigurationEndpoint {
++ (void)initForcedHE:(NSString *)wellKnownConfigurationEndpoint {
     curl_global_init(CURL_GLOBAL_DEFAULT);
-
+    
     [self fetchWellknown:wellKnownConfigurationEndpoint];
 }
 
-+ (void) fetchWellknown:(NSString *)wellKnownConfigurationEndpoint {
-    NSURLRequest *request = [[NSURLRequest alloc] initWithURL:[NSURL URLWithString:wellKnownConfigurationEndpoint]];
-
++ (void)fetchWellknown:(NSString *)wellKnownConfigurationEndpoint {
+    NSURL *URL = [NSURL URLWithString:wellKnownConfigurationEndpoint];
+    
     __block NSDictionary *json;
-    [NSURLConnection sendAsynchronousRequest:request
-                                       queue:[NSOperationQueue mainQueue]
-                           completionHandler:^(NSURLResponse *response, NSData *data, NSError *connectionError) {
-                               json = [NSJSONSerialization JSONObjectWithData:data
-                                                                      options:0
-                                                                        error:nil];
-                               @synchronized(self) {
-                                   _urlsForHE = json[@"network_authentication_target_urls"];
-                               }
-                           }];
+    
+    NSURLSession *session = [NSURLSession sessionWithConfiguration:[NSURLSessionConfiguration defaultSessionConfiguration] delegate:nil delegateQueue:[NSOperationQueue mainQueue]];
+    [[session dataTaskWithURL:URL
+            completionHandler:^(NSData *data,
+                                NSURLResponse *response,
+                                NSError *error) {
+                if (error) {
+                    NSLog(@"Error fetching data from the endpoint");
+                } else {
+                    if (data) {
+                        NSError *serializationError = nil;
+                        json = [NSJSONSerialization JSONObjectWithData:data
+                                                               options:0
+                                                                 error:&serializationError];
+                        if (serializationError != nil) {
+                            NSLog(@"Error serializing the data");
+                        } else {
+                            @synchronized(self) {
+                                _urlsForHE = json[@"network_authentication_target_urls"];
+                            }
+                        }
+                    }
+                }
+            }] resume];
 }
 
-+ (bool) isInterfaceEnabled:(NSString *)iface {
++ (bool)isInterfaceEnabled:(NSString *)iface {
     struct ifaddrs *interfaces = nil;
     struct ifaddrs *current_interface = nil;
     NSInteger success = getifaddrs(&interfaces);
@@ -54,20 +68,20 @@ static NSSet *_urlsForHE = nil;
         }
         current_interface = current_interface->ifa_next;
     }
-
+    
     return false;
 }
 
-+ (bool) isWifiEnabled {
++ (bool)isWifiEnabled {
     return [self isInterfaceEnabled:@"en0"];
 }
 
-+ (bool) isCellularEnabled {
++ (bool)isCellularEnabled {
     return [self isInterfaceEnabled:@"pdp_ip0"];
 }
 
 
-+ (bool) shouldFetchThroughCellular:(NSString *)url {
++ (bool)shouldFetchThroughCellular:(NSString *)url {
     @synchronized(self) {
         for (NSString *urlForHE in _urlsForHE) {
             if ([url containsString:urlForHE]) {
@@ -104,38 +118,38 @@ struct MemoryStruct {
 static size_t WriteMemoryCallback(void *contents, size_t size, size_t nmemb, void *userp) {
     size_t realsize = size * nmemb;
     struct MemoryStruct *mem = (struct MemoryStruct *)userp;
-
+    
     mem->memory = realloc(mem->memory, mem->size + realsize + 1);
     if (mem->memory == NULL) {
         /* out of memory! */
         exit(EXIT_FAILURE);
     }
-
+    
     memcpy(&(mem->memory[mem->size]), contents, realsize);
     mem->size += realsize;
     mem->memory[mem->size] = 0;
-
+    
     return realsize;
 }
 
-+ (NSDictionary*) openUrlThroughCellular:(NSString *)url {
++ (NSDictionary*)openUrlThroughCellular:(NSString *)url {
     bool useCellular = true;
     CURL *curl;
     NSString *newUrl = url;
     NSDictionary *resDict = @{};
     int attempts = 0;
-
+    
     do {
         curl = curl_easy_init();
         if (!curl) {
             return @{};
         }
-
+        
         curl_easy_setopt(curl, CURLOPT_OPENSOCKETFUNCTION, opensocket);
         curl_easy_setopt(curl, CURLOPT_SOCKOPTFUNCTION, sockopt_callback);
         curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, 0L);
         curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, WriteMemoryCallback);
-
+        
         //socket
         int socketfd = socket(AF_INET, SOCK_STREAM, 0);
         int interfaceIndex;
@@ -146,45 +160,45 @@ static size_t WriteMemoryCallback(void *contents, size_t size, size_t nmemb, voi
         }
         setsockopt(socketfd, IPPROTO_IP, IP_BOUND_IF, &interfaceIndex, sizeof(interfaceIndex));
         curl_easy_setopt(curl, CURLOPT_OPENSOCKETDATA, &socketfd);
-
-
+        
+        
         // memory
         struct MemoryStruct chunk;
         chunk.memory = malloc(1);
         chunk.size = 0;
         curl_easy_setopt(curl, CURLOPT_WRITEDATA, (void *)&chunk);
-
+        
         // request
         curl_easy_setopt(curl, CURLOPT_URL, [newUrl UTF8String]);
         CURLcode res = curl_easy_perform(curl);
         attempts += 1;
-
+        
         // free memory
         NSData *data = [NSData dataWithBytes:chunk.memory length:chunk.size];
         if(chunk.memory) {
             free(chunk.memory);
             chunk.memory = NULL;
         }
-
+        
         if (res != CURLE_OK) {
             NSLog(@"curl_easy_perform() failed: %s\n", curl_easy_strerror(res));
             break;
         }
-
+        
         long responseCode;
         curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &responseCode);
-
+        
         if (responseCode != 303 && responseCode != 302 && responseCode != 301) {
             char *pszContentType;
             curl_easy_getinfo(curl, CURLINFO_CONTENT_TYPE, &pszContentType);
             resDict =  @{@"responseCode" : [NSNumber numberWithLong:responseCode], @"contentType" : [NSString stringWithUTF8String:pszContentType], @"data": data};
             break;
         }
-
+        
         if (attempts > MAX_REDIRECTS_TO_FOLLOW_FOR_HE) {
             break;
         }
-
+        
         char *location;
         curl_easy_getinfo(curl, CURLINFO_REDIRECT_URL, &location);
         newUrl = [NSString stringWithUTF8String:location];
@@ -192,10 +206,10 @@ static size_t WriteMemoryCallback(void *contents, size_t size, size_t nmemb, voi
             break;
         }
         useCellular = [self shouldFetchThroughCellular:newUrl];
-
+        
         curl_easy_cleanup(curl);
     } while (1);
-
+    
     curl_easy_cleanup(curl);
     return resDict;
 }

--- a/TDConnectIosSdk/ForcedHEManager.m
+++ b/TDConnectIosSdk/ForcedHEManager.m
@@ -26,7 +26,7 @@ static NSSet *_urlsForHE = nil;
 
     __block NSDictionary *json;
     
-    NSURLSession *session = [NSURLSession sessionWithConfiguration:[NSURLSessionConfiguration defaultSessionConfiguration]];
+    NSURLSession *session = [NSURLSession sharedSession];
     [[session dataTaskWithURL:URL completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
                 if (error || !data) {
                     NSLog(@"Error fetching data from the endpoint %@", [error localizedDescription]);

--- a/TDConnectIosSdkTests/ForcedHEManagerTest.swift
+++ b/TDConnectIosSdkTests/ForcedHEManagerTest.swift
@@ -1,0 +1,9 @@
+//
+//  ForcedHEManagerTest.swift
+//  TDConnectIosSdkTests
+//
+//  Created by Sergio Ramirez on 2017-12-02.
+//  Copyright © 2017 aerogear. All rights reserved.
+//
+
+import Foundation

--- a/TDConnectIosSdkTests/ForcedHEManagerTest.swift
+++ b/TDConnectIosSdkTests/ForcedHEManagerTest.swift
@@ -2,8 +2,81 @@
 //  ForcedHEManagerTest.swift
 //  TDConnectIosSdkTests
 //
-//  Created by Sergio Ramirez on 2017-12-02.
-//  Copyright © 2017 aerogear. All rights reserved.
-//
 
 import Foundation
+import XCTest
+import TDConnectIosSdk
+import AeroGearHttp
+import OHHTTPStubs
+
+func setupForcedStubWithNSURLSessionDefaultConfiguration() {
+    // set up http stub
+    _ = stub({_ in return true}, response: { (request: URLRequest!) -> OHHTTPStubsResponse in
+        //_ = ["name": "John", "family_name": "Smith"]
+        switch request.url!.path {
+        case "/oauth/.well-known/openid-configuration":
+            let string = "{\"grant_types_supported\": [\"refresh_token\",\"authorization_code\"],\"id_token_signing_alg_values_supported\": [\"RS256\",\"none\"]}"
+            let data = string.data(using: String.Encoding.utf8)
+            return OHHTTPStubsResponse(data:data!, statusCode: 200, headers: ["Content-Type" : "text/json"])
+        case "/oauth/.well-known/openid-configuration-bad-url":
+            let string = ""
+            let data = string.data(using: String.Encoding.utf8)
+            return OHHTTPStubsResponse(data:data!, statusCode: 200, headers: ["Content-Type" : "text/json"])
+        default:
+            return OHHTTPStubsResponse(error: NSError(domain: "TimeoutErrorDomain", code: URLError.timedOut.rawValue, userInfo: nil))
+        }
+    })
+}
+
+class ForcedHEManagerTestModuleTests: XCTestCase {
+    
+    override func setUp() {
+        super.setUp()
+        setupForcedStubWithNSURLSessionDefaultConfiguration()
+    }
+    
+    override func tearDown() {
+        super.tearDown()
+        OHHTTPStubs.removeAllStubs()
+    }
+    
+    func testGetRemoteConfiguration() {
+        let expectation = self.expectation(description: "GetRemoteConfiguration")
+        let baseUrl = "https://connect.staging.telenordigital.com/oauth"
+        let url = String(format: "%@", "\(baseUrl)/.well-known/openid-configuration")
+        
+        ForcedHEManager.fetchWellknown(url) { (success) in
+            XCTAssert(success)
+            expectation.fulfill()
+        }
+        
+        waitForExpectations(timeout: 10, handler: nil)
+    }
+    
+    func testGetRemoteConfigurationBadUrl() {
+        let expectation = self.expectation(description: "GetRemoteConfigurationBadUrl")
+        let baseUrl = "https://connect.staging.telenordigital.com/oauth"
+        let url = String(format: "%@", "\(baseUrl)/.well-known/openid-configuration-bad-url")
+        
+        ForcedHEManager.fetchWellknown(url) { (success) in
+            XCTAssert(!success)
+            expectation.fulfill()
+        }
+        
+        waitForExpectations(timeout: 10, handler: nil)
+    }
+    
+    func testGetRemoteConfigurationTimeout() {
+        let expectation = self.expectation(description: "GetRemoteConfigurationTimeout")
+        let baseUrl = "https://connect.staging.telenordigital.com/oauth"
+        let url = String(format: "%@", "\(baseUrl)")
+        
+        ForcedHEManager.fetchWellknown(url) { (success) in
+            XCTAssert(!success)
+            expectation.fulfill()
+        }
+        
+        waitForExpectations(timeout: 10, handler: nil)
+    }
+    
+}


### PR DESCRIPTION
Hi,

I am working on a project that uses this sdk, and I found a crash using a limited or very bad internet connection.

When that request reaches a timeout or the server responds an error, the data is nil, and, as there is no validation, the app crashes.

In order to avoid the crash, I added a simple validation of the callback parameters, and changed the way to create that request, because of the deprecation of `[NSURLConnection sendAsynchronousRequest:queue:completionHandler:]` method in iOS 9.

In addition, I updated the platform version in the podspec based on the latest version of the aerogearhttp dependency. 
My experience: when you add and install this pod in a fresh project, and you try to compile that project, you get an error about the iOS version.
(see https://github.com/aerogear/aerogear-ios-http/blob/master/AeroGearHttp.podspec)