### PR TITLE
Validation and changing the way how to create the request.

### DIFF
--- a/TDConnectIosSdk.xcodeproj/project.pbxproj
+++ b/TDConnectIosSdk.xcodeproj/project.pbxproj
@@ -41,6 +41,7 @@
 		5CF359B21CAA8C800064C43D /* IdTokenValidator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CF359B01CAA8C800064C43D /* IdTokenValidator.swift */; };
 		5CF359B31CAA8C800064C43D /* TelenorConnectOAuth2Module.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CF359B11CAA8C800064C43D /* TelenorConnectOAuth2Module.swift */; };
 		6F1432B81A168594003BEE5B /* TDConnectIosSdk.framework in Copy Frameworks */ = {isa = PBXBuildFile; fileRef = 4833046219AF1635002F8DA9 /* TDConnectIosSdk.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		84D373F11FD38C060072C433 /* ForcedHEManagerTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84D373F01FD38C060072C433 /* ForcedHEManagerTest.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -106,6 +107,7 @@
 		5CF359B11CAA8C800064C43D /* TelenorConnectOAuth2Module.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TelenorConnectOAuth2Module.swift; sourceTree = "<group>"; };
 		81AA15F7C5D0DEB4D9842A1A /* Pods_TDConnectIosSdk.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_TDConnectIosSdk.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		82795C1D3260B724DC6F6A00 /* Pods-TDConnectIosSdk.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TDConnectIosSdk.release.xcconfig"; path = "Pods/Target Support Files/Pods-TDConnectIosSdk/Pods-TDConnectIosSdk.release.xcconfig"; sourceTree = "<group>"; };
+		84D373F01FD38C060072C433 /* ForcedHEManagerTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ForcedHEManagerTest.swift; sourceTree = "<group>"; };
 		9ADB5FF0CB048392A40B2D60 /* Pods.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		B8BA81BC938C950FC172C5D7 /* Pods-TDConnectIosSdkTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TDConnectIosSdkTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-TDConnectIosSdkTests/Pods-TDConnectIosSdkTests.debug.xcconfig"; sourceTree = "<group>"; };
 		C6412BF91B7738BE06CECC5A /* Pods-TDConnectIosSdkTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TDConnectIosSdkTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-TDConnectIosSdkTests/Pods-TDConnectIosSdkTests.release.xcconfig"; sourceTree = "<group>"; };
@@ -214,6 +216,7 @@
 				48432BE81A2F727C00F7A0FF /* ConfigTest.swift */,
 				5C542B571CABD3C400039789 /* IdTokenValidatorTest.swift */,
 				4833046F19AF1635002F8DA9 /* Supporting Files */,
+				84D373F01FD38C060072C433 /* ForcedHEManagerTest.swift */,
 			);
 			path = TDConnectIosSdkTests;
 			sourceTree = "<group>";
@@ -481,6 +484,7 @@
 				4872F71A19EFE80F00F3FDE8 /* DateUtilsTest.swift in Sources */,
 				5C542B581CABD3C400039789 /* IdTokenValidatorTest.swift in Sources */,
 				485D737B1A35B6240007D9EC /* OpenIDConnectFacebookOAuth2ModuleTest.swift in Sources */,
+				84D373F11FD38C060072C433 /* ForcedHEManagerTest.swift in Sources */,
 				485AAB941A383FB500ABEBB2 /* OAuth2ModuleMock.swift in Sources */,
 				48432BE91A2F727C00F7A0FF /* ConfigTest.swift in Sources */,
 				48C94D8019C1F0970000ABBB /* OAuth2ModuleTest.swift in Sources */,

--- a/TDConnectIosSdk/Config.swift
+++ b/TDConnectIosSdk/Config.swift
@@ -16,6 +16,7 @@
 */
 
 import Foundation
+import UIKit
 
 /**
 Configuration object to setup an OAuth2 module

--- a/TDConnectIosSdk/ForcedHEManager.h
+++ b/TDConnectIosSdk/ForcedHEManager.h
@@ -4,11 +4,12 @@
 #import <Foundation/Foundation.h>
 
 @interface ForcedHEManager : NSObject
-+ (bool) isWifiEnabled;
-+ (bool) isCellularEnabled;
-+ (bool) shouldFetchThroughCellular:(NSString *)url;
++ (bool)isWifiEnabled;
++ (bool)isCellularEnabled;
++ (bool)shouldFetchThroughCellular:(NSString *)url;
 + (NSDictionary *) openUrlThroughCellular:(NSString *)url;
-+ (void) initForcedHE:(NSString *)wellKnownConfigurationEndpoint;
++ (void)initForcedHE:(NSString *)wellKnownConfigurationEndpoint;
++ (void)fetchWellknown:(NSString *)wellKnownConfigurationEndpoint completion:(void(^)(BOOL))completionHandler;
 @end
 
 #endif

--- a/TDConnectIosSdk/ForcedHEManager.m
+++ b/TDConnectIosSdk/ForcedHEManager.m
@@ -17,7 +17,7 @@ static NSSet *_urlsForHE = nil;
 
 + (void)initForcedHE:(NSString *)wellKnownConfigurationEndpoint {
     curl_global_init(CURL_GLOBAL_DEFAULT);
-    
+
     [self fetchWellknown:wellKnownConfigurationEndpoint completion:nil];
 }
 
@@ -25,7 +25,7 @@ static NSSet *_urlsForHE = nil;
     NSURL *URL = [NSURL URLWithString:wellKnownConfigurationEndpoint];
 
     __block NSDictionary *json;
-    
+
     NSURLSession *session = [NSURLSession sharedSession];
     [[session dataTaskWithURL:URL completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
                 if (error || !data) {
@@ -35,7 +35,7 @@ static NSSet *_urlsForHE = nil;
                     }
                     return;
                 }
-                
+
                 NSError *serializationError = nil;
                 json = [NSJSONSerialization JSONObjectWithData:data
                                                        options:0
@@ -47,11 +47,11 @@ static NSSet *_urlsForHE = nil;
                     }
                     return;
                 }
-                
+
                 @synchronized(self) {
                     _urlsForHE = json[@"network_authentication_target_urls"];
                 }
-                
+
                 if (completionHandler) {
                     completionHandler(true);
                 }
@@ -75,7 +75,7 @@ static NSSet *_urlsForHE = nil;
         }
         current_interface = current_interface->ifa_next;
     }
-    
+
     return false;
 }
 
@@ -86,7 +86,6 @@ static NSSet *_urlsForHE = nil;
 + (bool)isCellularEnabled {
     return [self isInterfaceEnabled:@"pdp_ip0"];
 }
-
 
 + (bool)shouldFetchThroughCellular:(NSString *)url {
     @synchronized(self) {
@@ -125,17 +124,17 @@ struct MemoryStruct {
 static size_t WriteMemoryCallback(void *contents, size_t size, size_t nmemb, void *userp) {
     size_t realsize = size * nmemb;
     struct MemoryStruct *mem = (struct MemoryStruct *)userp;
-    
+
     mem->memory = realloc(mem->memory, mem->size + realsize + 1);
     if (mem->memory == NULL) {
         /* out of memory! */
         exit(EXIT_FAILURE);
     }
-    
+
     memcpy(&(mem->memory[mem->size]), contents, realsize);
     mem->size += realsize;
     mem->memory[mem->size] = 0;
-    
+
     return realsize;
 }
 
@@ -145,18 +144,18 @@ static size_t WriteMemoryCallback(void *contents, size_t size, size_t nmemb, voi
     NSString *newUrl = url;
     NSDictionary *resDict = @{};
     int attempts = 0;
-    
+
     do {
         curl = curl_easy_init();
         if (!curl) {
             return @{};
         }
-        
+
         curl_easy_setopt(curl, CURLOPT_OPENSOCKETFUNCTION, opensocket);
         curl_easy_setopt(curl, CURLOPT_SOCKOPTFUNCTION, sockopt_callback);
         curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, 0L);
         curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, WriteMemoryCallback);
-        
+
         //socket
         int socketfd = socket(AF_INET, SOCK_STREAM, 0);
         int interfaceIndex;
@@ -167,34 +166,33 @@ static size_t WriteMemoryCallback(void *contents, size_t size, size_t nmemb, voi
         }
         setsockopt(socketfd, IPPROTO_IP, IP_BOUND_IF, &interfaceIndex, sizeof(interfaceIndex));
         curl_easy_setopt(curl, CURLOPT_OPENSOCKETDATA, &socketfd);
-        
-        
+
         // memory
         struct MemoryStruct chunk;
         chunk.memory = malloc(1);
         chunk.size = 0;
         curl_easy_setopt(curl, CURLOPT_WRITEDATA, (void *)&chunk);
-        
+
         // request
         curl_easy_setopt(curl, CURLOPT_URL, [newUrl UTF8String]);
         CURLcode res = curl_easy_perform(curl);
         attempts += 1;
-        
+
         // free memory
         NSData *data = [NSData dataWithBytes:chunk.memory length:chunk.size];
         if(chunk.memory) {
             free(chunk.memory);
             chunk.memory = NULL;
         }
-        
+
         if (res != CURLE_OK) {
             NSLog(@"curl_easy_perform() failed: %s\n", curl_easy_strerror(res));
             break;
         }
-        
+
         long responseCode;
         curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &responseCode);
-        
+
         if (responseCode != 303 && responseCode != 302 && responseCode != 301) {
             char *pszContentType;
             curl_easy_getinfo(curl, CURLINFO_CONTENT_TYPE, &pszContentType);
@@ -203,11 +201,11 @@ static size_t WriteMemoryCallback(void *contents, size_t size, size_t nmemb, voi
                          @"data": data};
             break;
         }
-        
+
         if (attempts > MAX_REDIRECTS_TO_FOLLOW_FOR_HE) {
             break;
         }
-        
+
         char *location;
         curl_easy_getinfo(curl, CURLINFO_REDIRECT_URL, &location);
         newUrl = [NSString stringWithUTF8String:location];
@@ -215,10 +213,10 @@ static size_t WriteMemoryCallback(void *contents, size_t size, size_t nmemb, voi
             break;
         }
         useCellular = [self shouldFetchThroughCellular:newUrl];
-        
+
         curl_easy_cleanup(curl);
     } while (1);
-    
+
     curl_easy_cleanup(curl);
     return resDict;
 }

--- a/TDConnectIosSdk/ForcedHEManager.m
+++ b/TDConnectIosSdk/ForcedHEManager.m
@@ -15,29 +15,50 @@ int MAX_REDIRECTS_TO_FOLLOW_FOR_HE = 5;
 
 static NSSet *_urlsForHE = nil;
 
-+ (void) initForcedHE:(NSString *)wellKnownConfigurationEndpoint {
++ (void)initForcedHE:(NSString *)wellKnownConfigurationEndpoint {
     curl_global_init(CURL_GLOBAL_DEFAULT);
-
-    [self fetchWellknown:wellKnownConfigurationEndpoint];
+    
+    [self fetchWellknown:wellKnownConfigurationEndpoint completion:nil];
 }
 
-+ (void) fetchWellknown:(NSString *)wellKnownConfigurationEndpoint {
-    NSURLRequest *request = [[NSURLRequest alloc] initWithURL:[NSURL URLWithString:wellKnownConfigurationEndpoint]];
++ (void)fetchWellknown:(NSString *)wellKnownConfigurationEndpoint completion:(void(^)(BOOL))completionHandler {
+    NSURL *URL = [NSURL URLWithString:wellKnownConfigurationEndpoint];
 
     __block NSDictionary *json;
-    [NSURLConnection sendAsynchronousRequest:request
-                                       queue:[NSOperationQueue mainQueue]
-                           completionHandler:^(NSURLResponse *response, NSData *data, NSError *connectionError) {
-                               json = [NSJSONSerialization JSONObjectWithData:data
-                                                                      options:0
-                                                                        error:nil];
-                               @synchronized(self) {
-                                   _urlsForHE = json[@"network_authentication_target_urls"];
-                               }
-                           }];
+    
+    NSURLSession *session = [NSURLSession sharedSession];
+    [[session dataTaskWithURL:URL completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
+                if (error || !data) {
+                    NSLog(@"Error fetching data from the endpoint %@", [error localizedDescription]);
+                    if (completionHandler) {
+                        completionHandler(false);
+                    }
+                    return;
+                }
+                
+                NSError *serializationError = nil;
+                json = [NSJSONSerialization JSONObjectWithData:data
+                                                       options:0
+                                                         error:&serializationError];
+                if (serializationError) {
+                    NSLog(@"Error serializing the data %@", [serializationError localizedDescription]);
+                    if (completionHandler) {
+                        completionHandler(false);
+                    }
+                    return;
+                }
+                
+                @synchronized(self) {
+                    _urlsForHE = json[@"network_authentication_target_urls"];
+                }
+                
+                if (completionHandler) {
+                    completionHandler(true);
+                }
+    }] resume];
 }
 
-+ (bool) isInterfaceEnabled:(NSString *)iface {
++ (bool)isInterfaceEnabled:(NSString *)iface {
     struct ifaddrs *interfaces = nil;
     struct ifaddrs *current_interface = nil;
     NSInteger success = getifaddrs(&interfaces);
@@ -54,20 +75,20 @@ static NSSet *_urlsForHE = nil;
         }
         current_interface = current_interface->ifa_next;
     }
-
+    
     return false;
 }
 
-+ (bool) isWifiEnabled {
++ (bool)isWifiEnabled {
     return [self isInterfaceEnabled:@"en0"];
 }
 
-+ (bool) isCellularEnabled {
++ (bool)isCellularEnabled {
     return [self isInterfaceEnabled:@"pdp_ip0"];
 }
 
 
-+ (bool) shouldFetchThroughCellular:(NSString *)url {
++ (bool)shouldFetchThroughCellular:(NSString *)url {
     @synchronized(self) {
         for (NSString *urlForHE in _urlsForHE) {
             if ([url containsString:urlForHE]) {
@@ -104,38 +125,38 @@ struct MemoryStruct {
 static size_t WriteMemoryCallback(void *contents, size_t size, size_t nmemb, void *userp) {
     size_t realsize = size * nmemb;
     struct MemoryStruct *mem = (struct MemoryStruct *)userp;
-
+    
     mem->memory = realloc(mem->memory, mem->size + realsize + 1);
     if (mem->memory == NULL) {
         /* out of memory! */
         exit(EXIT_FAILURE);
     }
-
+    
     memcpy(&(mem->memory[mem->size]), contents, realsize);
     mem->size += realsize;
     mem->memory[mem->size] = 0;
-
+    
     return realsize;
 }
 
-+ (NSDictionary*) openUrlThroughCellular:(NSString *)url {
++ (NSDictionary*)openUrlThroughCellular:(NSString *)url {
     bool useCellular = true;
     CURL *curl;
     NSString *newUrl = url;
     NSDictionary *resDict = @{};
     int attempts = 0;
-
+    
     do {
         curl = curl_easy_init();
         if (!curl) {
             return @{};
         }
-
+        
         curl_easy_setopt(curl, CURLOPT_OPENSOCKETFUNCTION, opensocket);
         curl_easy_setopt(curl, CURLOPT_SOCKOPTFUNCTION, sockopt_callback);
         curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, 0L);
         curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, WriteMemoryCallback);
-
+        
         //socket
         int socketfd = socket(AF_INET, SOCK_STREAM, 0);
         int interfaceIndex;
@@ -146,45 +167,47 @@ static size_t WriteMemoryCallback(void *contents, size_t size, size_t nmemb, voi
         }
         setsockopt(socketfd, IPPROTO_IP, IP_BOUND_IF, &interfaceIndex, sizeof(interfaceIndex));
         curl_easy_setopt(curl, CURLOPT_OPENSOCKETDATA, &socketfd);
-
-
+        
+        
         // memory
         struct MemoryStruct chunk;
         chunk.memory = malloc(1);
         chunk.size = 0;
         curl_easy_setopt(curl, CURLOPT_WRITEDATA, (void *)&chunk);
-
+        
         // request
         curl_easy_setopt(curl, CURLOPT_URL, [newUrl UTF8String]);
         CURLcode res = curl_easy_perform(curl);
         attempts += 1;
-
+        
         // free memory
         NSData *data = [NSData dataWithBytes:chunk.memory length:chunk.size];
         if(chunk.memory) {
             free(chunk.memory);
             chunk.memory = NULL;
         }
-
+        
         if (res != CURLE_OK) {
             NSLog(@"curl_easy_perform() failed: %s\n", curl_easy_strerror(res));
             break;
         }
-
+        
         long responseCode;
         curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &responseCode);
-
+        
         if (responseCode != 303 && responseCode != 302 && responseCode != 301) {
             char *pszContentType;
             curl_easy_getinfo(curl, CURLINFO_CONTENT_TYPE, &pszContentType);
-            resDict =  @{@"responseCode" : [NSNumber numberWithLong:responseCode], @"contentType" : [NSString stringWithUTF8String:pszContentType], @"data": data};
+            resDict =  @{@"responseCode" : [NSNumber numberWithLong:responseCode],
+                         @"contentType" : [NSString stringWithUTF8String:pszContentType],
+                         @"data": data};
             break;
         }
-
+        
         if (attempts > MAX_REDIRECTS_TO_FOLLOW_FOR_HE) {
             break;
         }
-
+        
         char *location;
         curl_easy_getinfo(curl, CURLINFO_REDIRECT_URL, &location);
         newUrl = [NSString stringWithUTF8String:location];
@@ -192,10 +215,10 @@ static size_t WriteMemoryCallback(void *contents, size_t size, size_t nmemb, voi
             break;
         }
         useCellular = [self shouldFetchThroughCellular:newUrl];
-
+        
         curl_easy_cleanup(curl);
     } while (1);
-
+    
     curl_easy_cleanup(curl);
     return resDict;
 }

--- a/TDConnectIosSdk/TDConnectIosSdk.h
+++ b/TDConnectIosSdk/TDConnectIosSdk.h
@@ -5,3 +5,5 @@
 #define __warning__ deprecated
 
 #endif
+
+#import "ForcedHEManager.h"

--- a/TDConnectIosSdkTests/ForcedHEManagerTest.swift
+++ b/TDConnectIosSdkTests/ForcedHEManagerTest.swift
@@ -29,54 +29,55 @@ func setupForcedStubWithNSURLSessionDefaultConfiguration() {
 }
 
 class ForcedHEManagerTestModuleTests: XCTestCase {
-    
+
     override func setUp() {
         super.setUp()
         setupForcedStubWithNSURLSessionDefaultConfiguration()
     }
-    
+
     override func tearDown() {
         super.tearDown()
         OHHTTPStubs.removeAllStubs()
     }
-    
+
     func testGetRemoteConfiguration() {
         let expectation = self.expectation(description: "GetRemoteConfiguration")
         let baseUrl = "https://connect.staging.telenordigital.com/oauth"
         let url = String(format: "%@", "\(baseUrl)/.well-known/openid-configuration")
-        
+
         ForcedHEManager.fetchWellknown(url) { (success) in
             XCTAssert(success)
             expectation.fulfill()
         }
-        
+
         waitForExpectations(timeout: 10, handler: nil)
     }
-    
+
     func testGetRemoteConfigurationBadUrl() {
         let expectation = self.expectation(description: "GetRemoteConfigurationBadUrl")
         let baseUrl = "https://connect.staging.telenordigital.com/oauth"
         let url = String(format: "%@", "\(baseUrl)/.well-known/openid-configuration-bad-url")
-        
+
         ForcedHEManager.fetchWellknown(url) { (success) in
             XCTAssert(!success)
             expectation.fulfill()
         }
-        
+
         waitForExpectations(timeout: 10, handler: nil)
     }
-    
+
     func testGetRemoteConfigurationTimeout() {
         let expectation = self.expectation(description: "GetRemoteConfigurationTimeout")
         let baseUrl = "https://connect.staging.telenordigital.com/oauth"
         let url = String(format: "%@", "\(baseUrl)")
-        
+
         ForcedHEManager.fetchWellknown(url) { (success) in
             XCTAssert(!success)
             expectation.fulfill()
         }
-        
+
         waitForExpectations(timeout: 10, handler: nil)
     }
-    
+
 }
+

--- a/TDConnectIosSdkTests/ForcedHEManagerTest.swift
+++ b/TDConnectIosSdkTests/ForcedHEManagerTest.swift
@@ -1,0 +1,82 @@
+//
+//  ForcedHEManagerTest.swift
+//  TDConnectIosSdkTests
+//
+
+import Foundation
+import XCTest
+import TDConnectIosSdk
+import AeroGearHttp
+import OHHTTPStubs
+
+func setupForcedStubWithNSURLSessionDefaultConfiguration() {
+    // set up http stub
+    _ = stub({_ in return true}, response: { (request: URLRequest!) -> OHHTTPStubsResponse in
+        //_ = ["name": "John", "family_name": "Smith"]
+        switch request.url!.path {
+        case "/oauth/.well-known/openid-configuration":
+            let string = "{\"grant_types_supported\": [\"refresh_token\",\"authorization_code\"],\"id_token_signing_alg_values_supported\": [\"RS256\",\"none\"]}"
+            let data = string.data(using: String.Encoding.utf8)
+            return OHHTTPStubsResponse(data:data!, statusCode: 200, headers: ["Content-Type" : "text/json"])
+        case "/oauth/.well-known/openid-configuration-bad-url":
+            let string = ""
+            let data = string.data(using: String.Encoding.utf8)
+            return OHHTTPStubsResponse(data:data!, statusCode: 200, headers: ["Content-Type" : "text/json"])
+        default:
+            return OHHTTPStubsResponse(error: NSError(domain: "TimeoutErrorDomain", code: URLError.timedOut.rawValue, userInfo: nil))
+        }
+    })
+}
+
+class ForcedHEManagerTestModuleTests: XCTestCase {
+    
+    override func setUp() {
+        super.setUp()
+        setupForcedStubWithNSURLSessionDefaultConfiguration()
+    }
+    
+    override func tearDown() {
+        super.tearDown()
+        OHHTTPStubs.removeAllStubs()
+    }
+    
+    func testGetRemoteConfiguration() {
+        let expectation = self.expectation(description: "GetRemoteConfiguration")
+        let baseUrl = "https://connect.staging.telenordigital.com/oauth"
+        let url = String(format: "%@", "\(baseUrl)/.well-known/openid-configuration")
+        
+        ForcedHEManager.fetchWellknown(url) { (success) in
+            XCTAssert(success)
+            expectation.fulfill()
+        }
+        
+        waitForExpectations(timeout: 10, handler: nil)
+    }
+    
+    func testGetRemoteConfigurationBadUrl() {
+        let expectation = self.expectation(description: "GetRemoteConfigurationBadUrl")
+        let baseUrl = "https://connect.staging.telenordigital.com/oauth"
+        let url = String(format: "%@", "\(baseUrl)/.well-known/openid-configuration-bad-url")
+        
+        ForcedHEManager.fetchWellknown(url) { (success) in
+            XCTAssert(!success)
+            expectation.fulfill()
+        }
+        
+        waitForExpectations(timeout: 10, handler: nil)
+    }
+    
+    func testGetRemoteConfigurationTimeout() {
+        let expectation = self.expectation(description: "GetRemoteConfigurationTimeout")
+        let baseUrl = "https://connect.staging.telenordigital.com/oauth"
+        let url = String(format: "%@", "\(baseUrl)")
+        
+        ForcedHEManager.fetchWellknown(url) { (success) in
+            XCTAssert(!success)
+            expectation.fulfill()
+        }
+        
+        waitForExpectations(timeout: 10, handler: nil)
+    }
+    
+}

--- a/TDConnectIosSdkTests/OAuth2ModuleTest.swift
+++ b/TDConnectIosSdkTests/OAuth2ModuleTest.swift
@@ -193,8 +193,8 @@ class OAuth2ModuleTests: XCTestCase {
             useStaging: true,
             scopes: ["scope1", "scope2"],
             accountId: "accountId",
-            claims: ["claim1", "claim2"],
-            webView: false)
+            webView: false,
+            claims: ["claim1", "claim2"])
         let mockedSession = MockOAuth2SessionWithRefreshToken()
         let oauth2Module: OAuth2Module = TelenorConnectOAuth2Module(config: config, session: mockedSession)
         oauth2Module.revokeAccess { (success, error) in
@@ -224,12 +224,12 @@ class OAuth2ModuleTests: XCTestCase {
             useStaging: true,
             scopes: ["scope1", "scope2"],
             accountId: "accountId",
+            webView: false,
             claims: ["claim1", "claim2"],
-            optionalParams: ["optParam1Key": "optParam1Value", "optParam2Key": "optParam2Value"],
-            webView: false)
+            optionalParams: ["optParam1Key": "optParam1Value", "optParam2Key": "optParam2Value"])
         let http = Http(baseURL: "https://connect.staging.telenordigital.com/oauth")
         do {
-            let url = try OAuth2Module.getAuthUrl(config: config, http: http)
+            let url = try OAuth2Module.getAuthUrl(config: config, http: http, browserType: BrowserType.unknown)
             XCTAssertNotNil(url.query?.range(of: "&claims=%7B%22userinfo%22%3A%7B%22claim1%22%3A%7B%22essential%22%3Atrue%7D%2C%22claim2%22%3A%7B%22essential%22%3Atrue%7D%7D%7D"))
         } catch {
             XCTFail("Failed to getAuthUrl with config=\(config) and http=\(http)")
@@ -243,12 +243,12 @@ class OAuth2ModuleTests: XCTestCase {
             useStaging: true,
             scopes: ["scope1", "scope2"],
             accountId: "accountId",
+            webView: false,
             claims: nil,
-            optionalParams: ["optParam1Key": "optParam1Value", "optParam2Key": "optParam2Value"],
-            webView: false)
+            optionalParams: ["optParam1Key": "optParam1Value", "optParam2Key": "optParam2Value"])
         let http = Http(baseURL: "https://connect.staging.telenordigital.com/oauth")
         do {
-            let url = try OAuth2Module.getAuthUrl(config: config, http: http)
+            let url = try OAuth2Module.getAuthUrl(config: config, http: http, browserType: BrowserType.unknown)
             XCTAssertNil(url.query?.range(of: "&claims="))
         } catch {
             XCTFail("Failed to getAuthUrl with config=\(config) and http=\(http)")
@@ -262,12 +262,12 @@ class OAuth2ModuleTests: XCTestCase {
             useStaging: true,
             scopes: ["scope1", "scope2"],
             accountId: "accountId",
+            webView: false,
             claims: nil,
-            optionalParams: ["optParam1Key": "optParam1Value", "optParam2Key": "optParam2Value"],
-            webView: false)
+            optionalParams: ["optParam1Key": "optParam1Value", "optParam2Key": "optParam2Value"])
         let http = Http(baseURL: "https://connect.staging.telenordigital.com/oauth")
         do {
-            let url = try OAuth2Module.getAuthUrl(config: config, http: http)
+            let url = try OAuth2Module.getAuthUrl(config: config, http: http, browserType: BrowserType.unknown)
             XCTAssertNil(url.query?.range(of: "&scope=scope1%20scope2"))
         } catch {
             XCTFail("Failed to getAuthUrl with config=\(config) and http=\(http)")


### PR DESCRIPTION
Hi,

I am working on a project that uses this sdk, and I found a crash using a limited or very bad internet connection.

When that request reaches a timeout or the server responds an error, the data is nil, and, as there is no validation, the app crashes.

In order to avoid the crash, I added a simple validation of the callback parameters, and changed the way to create that request, because of the deprecation of `[NSURLConnection sendAsynchronousRequest:queue:completionHandler:] `method in iOS 9.

In addition, I added a single test of the modified method to ensure that everything looks good.

Minor changes were added in order to compile the project (due to recommendations of the IDE) and to run the test.

I removed the previous PR and created this one to be more organized and clear. I saw and tried to follow all of your feedback.