### PR TITLE
Validate ID token upon receiving it instead of when reading it

### DIFF
--- a/TDConnectIosSdk.xcodeproj/project.pbxproj
+++ b/TDConnectIosSdk.xcodeproj/project.pbxproj
@@ -37,6 +37,7 @@
 		48DE90A619CDEAEE007F9B21 /* KeycloakOAuth2Module.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48DE90A519CDEAEE007F9B21 /* KeycloakOAuth2Module.swift */; };
 		48F79D9D1ABC191E00D8B712 /* OAuth2WebViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48F79D9C1ABC191E00D8B712 /* OAuth2WebViewController.swift */; };
 		5C542B581CABD3C400039789 /* IdTokenValidatorTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C542B571CABD3C400039789 /* IdTokenValidatorTest.swift */; };
+		5C8F38A2205A72260008756F /* JsonResponseSerializerWithDate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C8F38A1205A72260008756F /* JsonResponseSerializerWithDate.swift */; };
 		5CF359B21CAA8C800064C43D /* IdTokenValidator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CF359B01CAA8C800064C43D /* IdTokenValidator.swift */; };
 		5CF359B31CAA8C800064C43D /* TelenorConnectOAuth2Module.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CF359B11CAA8C800064C43D /* TelenorConnectOAuth2Module.swift */; };
 		6F1432B81A168594003BEE5B /* TDConnectIosSdk.framework in Copy Frameworks */ = {isa = PBXBuildFile; fileRef = 4833046219AF1635002F8DA9 /* TDConnectIosSdk.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
@@ -104,6 +105,7 @@
 		48DE90A519CDEAEE007F9B21 /* KeycloakOAuth2Module.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = KeycloakOAuth2Module.swift; sourceTree = "<group>"; };
 		48F79D9C1ABC191E00D8B712 /* OAuth2WebViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OAuth2WebViewController.swift; sourceTree = "<group>"; };
 		5C542B571CABD3C400039789 /* IdTokenValidatorTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IdTokenValidatorTest.swift; sourceTree = "<group>"; };
+		5C8F38A1205A72260008756F /* JsonResponseSerializerWithDate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JsonResponseSerializerWithDate.swift; sourceTree = "<group>"; };
 		5CF359B01CAA8C800064C43D /* IdTokenValidator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IdTokenValidator.swift; sourceTree = "<group>"; };
 		5CF359B11CAA8C800064C43D /* TelenorConnectOAuth2Module.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TelenorConnectOAuth2Module.swift; sourceTree = "<group>"; };
 		84D373F01FD38C060072C433 /* ForcedHEManagerTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ForcedHEManagerTest.swift; sourceTree = "<group>"; };
@@ -169,6 +171,7 @@
 				48CD52D619B0C1CB008D0694 /* OAuth2Module.swift */,
 				485D73801A35BCBC0007D9EC /* OpenIDClaim.swift */,
 				5CF359B01CAA8C800064C43D /* IdTokenValidator.swift */,
+				5C8F38A1205A72260008756F /* JsonResponseSerializerWithDate.swift */,
 				5CF359B11CAA8C800064C43D /* TelenorConnectOAuth2Module.swift */,
 				48CD52DC19B0C22A008D0694 /* OAuth2Session.swift */,
 				4872F71519EFE7D100F3FDE8 /* DateUtils.swift */,
@@ -463,6 +466,7 @@
 				01BD2C581F28A2370051E77C /* ForcedHEURLProtocol.swift in Sources */,
 				485D73811A35BCBC0007D9EC /* OpenIDClaim.swift in Sources */,
 				48DE90A619CDEAEE007F9B21 /* KeycloakOAuth2Module.swift in Sources */,
+				5C8F38A2205A72260008756F /* JsonResponseSerializerWithDate.swift in Sources */,
 				01BD2C591F28A2370051E77C /* OperatorInfo.swift in Sources */,
 				5CF359B31CAA8C800064C43D /* TelenorConnectOAuth2Module.swift in Sources */,
 				48CD52DD19B0C22A008D0694 /* OAuth2Session.swift in Sources */,

--- a/TDConnectIosSdk/IdTokenValidator.swift
+++ b/TDConnectIosSdk/IdTokenValidator.swift
@@ -59,7 +59,7 @@ public func validateIdToken(token: [String:AnyObject], expectedIssuer: String, e
     }
     
     let expirationDate = Date(timeIntervalSince1970: experationTime)
-    if isInvalidExpirationTime(expirationDate: expirationDate, serverDate: serverTime) {
+    if !isValidExpirationTime(expirationDate: expirationDate, serverDate: serverTime) {
         return IdTokenValidationError.Expired("ID token has expired.")
     }
     
@@ -70,15 +70,15 @@ public func validateIdToken(token: [String:AnyObject], expectedIssuer: String, e
     return nil
 }
 
-func isInvalidExpirationTime(expirationDate: Date, serverDate: Date?) -> Bool {
+func isValidExpirationTime(expirationDate: Date, serverDate: Date?) -> Bool {
     if expirationDate.timeIntervalSinceNow.sign == FloatingPointSign.plus {
-        return false
-    }
-    
-    guard let serverDate = serverDate else {
         return true
     }
     
-    let expired = expirationDate <= serverDate
+    guard let serverDate = serverDate else {
+        return false
+    }
+    
+    let expired = expirationDate > serverDate
     return expired
 }

--- a/TDConnectIosSdk/JsonResponseSerializerWithDate.swift
+++ b/TDConnectIosSdk/JsonResponseSerializerWithDate.swift
@@ -22,9 +22,10 @@ open class JsonResponseSerializerWithDate: JsonResponseSerializer {
         self.validation = { (response: URLResponse?, data: Data) throws -> Void in
             try superValidation(response, data)
             let httpResponse = response as! HTTPURLResponse
-            if let contentType = httpResponse.allHeaderFields["Date"] as? String {
-                self.lastServerTime = self.dateFormatter.date(from: contentType)
+            guard let serverDate = httpResponse.allHeaderFields["Date"] as? String else {
+                return
             }
+            self.lastServerTime = self.dateFormatter.date(from: serverDate)
         }
     }
     

--- a/TDConnectIosSdk/JsonResponseSerializerWithDate.swift
+++ b/TDConnectIosSdk/JsonResponseSerializerWithDate.swift
@@ -1,0 +1,31 @@
+//
+//  TelenorConnectOAuth2Module.swift
+//  Pods
+//
+//  Created by Jørund Fagerjord on 15/03/18.
+//
+//
+
+import Foundation
+import AeroGearHttp
+
+open class JsonResponseSerializerWithDate: JsonResponseSerializer {
+    
+    let dateFormatter = DateFormatter()
+    
+    open var lastServerTime: Date?
+    
+    public override init() {
+        super.init()
+        dateFormatter.dateFormat = "EEE, dd MMM yyyy HH:mm:ss z"
+        let superValidation = self.validation
+        self.validation = { (response: URLResponse?, data: Data) throws -> Void in
+            try superValidation(response, data)
+            let httpResponse = response as! HTTPURLResponse
+            if let contentType = httpResponse.allHeaderFields["Date"] as? String {
+                self.lastServerTime = self.dateFormatter.date(from: contentType)
+            }
+        }
+    }
+    
+}

--- a/TDConnectIosSdk/JsonResponseSerializerWithDate.swift
+++ b/TDConnectIosSdk/JsonResponseSerializerWithDate.swift
@@ -1,5 +1,5 @@
 //
-//  TelenorConnectOAuth2Module.swift
+//  JsonResponseSerializerWithDate.swift
 //  Pods
 //
 //  Created by Jørund Fagerjord on 15/03/18.

--- a/TDConnectIosSdk/OAuth2Module.swift
+++ b/TDConnectIosSdk/OAuth2Module.swift
@@ -593,10 +593,7 @@ open class OAuth2Module: NSObject, AuthzModule, SFSafariViewControllerDelegate {
         }
         
         let serverTime = self.jsonResponseSerializerWithDate?.lastServerTime
-        if let failure = validateIdToken(token: token as [String : AnyObject], expectedIssuer: self.config.baseURL, expectedAudience: self.config.clientId, serverTime: serverTime) {
-            return failure
-        }
-        return nil
+        return validateIdToken(token: token as [String : AnyObject], expectedIssuer: self.config.baseURL, expectedAudience: self.config.clientId, serverTime: serverTime)
     }
     
     public func getIdTokenEncoded() -> String? {

--- a/TDConnectIosSdk/OAuth2Module.swift
+++ b/TDConnectIosSdk/OAuth2Module.swift
@@ -96,6 +96,7 @@ Parent class of any OAuth2 module implementing generic OAuth2 authorization flow
 open class OAuth2Module: NSObject, AuthzModule, SFSafariViewControllerDelegate {
     
     open let config: Config
+    let jsonResponseSerializerWithDate: JsonResponseSerializerWithDate?
     open var http: Http
     open var oauth2Session: OAuth2Session
     var applicationLaunchNotificationObserver: NSObjectProtocol?
@@ -114,7 +115,9 @@ open class OAuth2Module: NSObject, AuthzModule, SFSafariViewControllerDelegate {
 
     :returns: the newly initialized OAuth2Module.
     */
-    public required init(config: Config, session: OAuth2Session? = nil, requestSerializer: RequestSerializer = HttpRequestSerializer(), responseSerializer: ResponseSerializer = JsonResponseSerializer()) {
+    public required init(config: Config, session: OAuth2Session? = nil, requestSerializer: RequestSerializer = HttpRequestSerializer(), responseSerializer: ResponseSerializer = JsonResponseSerializerWithDate()) {
+        self.jsonResponseSerializerWithDate = responseSerializer as? JsonResponseSerializerWithDate
+
         if (config.accountId == nil) {
             config.accountId = "ACCOUNT_FOR_CLIENTID_\(config.clientId)"
         }
@@ -400,6 +403,14 @@ open class OAuth2Module: NSObject, AuthzModule, SFSafariViewControllerDelegate {
             let expirationRefresh = unwrappedResponse["refresh_expires_in"] as? NSNumber
             let expRefresh = expirationRefresh?.stringValue
             
+            if idToken != nil {
+                let error = self.validateCodedIdToken(idToken: idToken!)
+                if (error != nil) {
+                    completionHandler(nil, error! as NSError)
+                    return
+                }
+            }
+            
             self.oauth2Session.save(accessToken: accessToken,
                 refreshToken: refreshToken,
                 accessTokenExpiration: exp,
@@ -565,18 +576,27 @@ open class OAuth2Module: NSObject, AuthzModule, SFSafariViewControllerDelegate {
         return parameters
     }
     
-    public func getIdTokenPayload() throws -> Payload? {
+    public func getIdTokenPayload() -> Payload? {
         guard let signedJwt = oauth2Session.idToken else {
             return nil
         }
 
-        let token = try JWT.decode(signedJwt, algorithm: .none, verify: false, audience: config.clientId, issuer: config.baseURL)
-        
-        if let failure = validateIdToken(token: token as [String : AnyObject], expectedIssuer: config.baseURL, expectedAudience: config.clientId) {
-            throw failure
+        return try? JWT.decode(signedJwt, algorithm: .none, verify: false, audience: config.clientId, issuer: config.baseURL)
+    }
+    
+    public func validateCodedIdToken(idToken: String) -> Error? {
+        var token: Payload
+        do {
+            token = try JWT.decode(idToken, algorithm: .none, verify: false, audience: self.config.clientId, issuer: self.config.baseURL)
+        } catch {
+            return error
         }
         
-        return token
+        let serverTime = self.jsonResponseSerializerWithDate?.lastServerTime
+        if let failure = validateIdToken(token: token as [String : AnyObject], expectedIssuer: self.config.baseURL, expectedAudience: self.config.clientId, serverTime: serverTime) {
+            return failure
+        }
+        return nil
     }
     
     public func getIdTokenEncoded() -> String? {

--- a/TDConnectIosSdkTests/IdTokenValidatorTest.swift
+++ b/TDConnectIosSdkTests/IdTokenValidatorTest.swift
@@ -17,7 +17,7 @@ class IdTokenValidatorTest: XCTestCase {
         let experationTime: String = String(Date().timeIntervalSince1970 + 100)
         let issueTime: String = String(Date().timeIntervalSince1970)
         let token: [String: Any] = ["aud": ["expectedAudience"], "exp": experationTime, "iat": issueTime]
-        let error: IdTokenValidationError? = validateIdToken(token: token as [String : AnyObject], expectedIssuer: "expectedIssuer", expectedAudience: "expectedAudience")
+        let error: IdTokenValidationError? = validateIdToken(token: token as [String : AnyObject], expectedIssuer: "expectedIssuer", expectedAudience: "expectedAudience", serverTime: nil)
         XCTAssertNotNil(error)
     }
     
@@ -25,7 +25,7 @@ class IdTokenValidatorTest: XCTestCase {
         let experationTime: String = String(Date().timeIntervalSince1970 + 100)
         let issueTime: String = String(Date().timeIntervalSince1970)
         let token: [String: Any] = ["iss": "expectedIssuerAlmost" as AnyObject, "aud": ["expectedAudience"], "exp": experationTime, "iat": issueTime]
-        let error: IdTokenValidationError? = validateIdToken(token: token as [String : AnyObject], expectedIssuer: "expectedIssuer", expectedAudience: "expectedAudience")
+        let error: IdTokenValidationError? = validateIdToken(token: token as [String : AnyObject], expectedIssuer: "expectedIssuer", expectedAudience: "expectedAudience", serverTime: nil)
         XCTAssertNotNil(error)
     }
     
@@ -33,7 +33,7 @@ class IdTokenValidatorTest: XCTestCase {
         let experationTime: String = String(Date().timeIntervalSince1970 + 100)
         let issueTime: String = String(Date().timeIntervalSince1970)
         let token: [String: AnyObject] = ["iss": "expectedIssuer" as AnyObject, "exp": experationTime as AnyObject, "iat": issueTime as AnyObject]
-        let error: IdTokenValidationError? = validateIdToken(token: token, expectedIssuer: "expectedIssuer", expectedAudience: "expectedAudience")
+        let error: IdTokenValidationError? = validateIdToken(token: token, expectedIssuer: "expectedIssuer", expectedAudience: "expectedAudience", serverTime: nil)
         XCTAssertNotNil(error)
     }
     
@@ -41,7 +41,7 @@ class IdTokenValidatorTest: XCTestCase {
         let experationTime: String = String(Date().timeIntervalSince1970 + 100)
         let issueTime: String = String(Date().timeIntervalSince1970)
         let token: [String: Any] = ["iss": "expectedIssuer" as AnyObject, "aud": [], "exp": experationTime, "iat": issueTime]
-        let error: IdTokenValidationError? = validateIdToken(token: token as [String : AnyObject], expectedIssuer: "expectedIssuer", expectedAudience: "expectedAudience")
+        let error: IdTokenValidationError? = validateIdToken(token: token as [String : AnyObject], expectedIssuer: "expectedIssuer", expectedAudience: "expectedAudience", serverTime: nil)
         XCTAssertNotNil(error)
     }
     
@@ -49,7 +49,7 @@ class IdTokenValidatorTest: XCTestCase {
         let experationTime: String = String(Date().timeIntervalSince1970 + 100)
         let issueTime: String = String(Date().timeIntervalSince1970)
         let token: [String: Any] = ["iss": "expectedIssuer" as AnyObject, "aud": ["untrustedAudience"], "exp": experationTime, "iat": issueTime]
-        let error: IdTokenValidationError? = validateIdToken(token: token as [String : AnyObject], expectedIssuer: "expectedIssuer", expectedAudience: "expectedAudience")
+        let error: IdTokenValidationError? = validateIdToken(token: token as [String : AnyObject], expectedIssuer: "expectedIssuer", expectedAudience: "expectedAudience", serverTime: nil)
         XCTAssertNotNil(error)
     }
     
@@ -57,7 +57,7 @@ class IdTokenValidatorTest: XCTestCase {
         let experationTime: String = String(Date().timeIntervalSince1970 + 100)
         let issueTime: String = String(Date().timeIntervalSince1970)
         let token: [String: Any] = ["iss": "expectedIssuer" as AnyObject, "aud": ["expectedAudience", "untrustedAudience"], "exp": experationTime, "iat": issueTime]
-        let error: IdTokenValidationError? = validateIdToken(token: token as [String : AnyObject], expectedIssuer: "expectedIssuer", expectedAudience: "expectedAudience")
+        let error: IdTokenValidationError? = validateIdToken(token: token as [String : AnyObject], expectedIssuer: "expectedIssuer", expectedAudience: "expectedAudience", serverTime: nil)
         XCTAssertNotNil(error)
     }
     
@@ -65,14 +65,14 @@ class IdTokenValidatorTest: XCTestCase {
         let experationTime: String = String(Date().timeIntervalSince1970 + 100)
         let issueTime: String = String(Date().timeIntervalSince1970)
         let token: [String: Any] = ["iss": "expectedIssuer" as AnyObject, "aud": ["expectedAudience", "someAudience"], "azp": "someAudience", "exp": experationTime, "iat": issueTime]
-        let error: IdTokenValidationError? = validateIdToken(token: token as [String : AnyObject], expectedIssuer: "expectedIssuer", expectedAudience: "expectedAudience")
+        let error: IdTokenValidationError? = validateIdToken(token: token as [String : AnyObject], expectedIssuer: "expectedIssuer", expectedAudience: "expectedAudience", serverTime: nil)
         XCTAssertNotNil(error)
     }
     
     func testMissingExperationTimeReturnsError() {
         let issueTime: String = String(Date().timeIntervalSince1970)
         let token: [String: Any] = ["iss": "expectedIssuer" as AnyObject, "aud": ["expectedAudience"], "iat": issueTime]
-        let error: IdTokenValidationError? = validateIdToken(token: token as [String : AnyObject], expectedIssuer: "expectedIssuer", expectedAudience: "expectedAudience")
+        let error: IdTokenValidationError? = validateIdToken(token: token as [String : AnyObject], expectedIssuer: "expectedIssuer", expectedAudience: "expectedAudience", serverTime: nil)
         XCTAssertNotNil(error)
     }
     
@@ -80,14 +80,32 @@ class IdTokenValidatorTest: XCTestCase {
         let experationTime: String = String(Date().timeIntervalSince1970 - 100)
         let issueTime: String = String(Date().timeIntervalSince1970)
         let token: [String: Any] = ["iss": "expectedIssuer" as AnyObject, "aud": ["expectedAudience"], "exp": experationTime, "iat": issueTime]
-        let error: IdTokenValidationError? = validateIdToken(token: token as [String : AnyObject], expectedIssuer: "expectedIssuer", expectedAudience: "expectedAudience")
+        let error: IdTokenValidationError? = validateIdToken(token: token as [String : AnyObject], expectedIssuer: "expectedIssuer", expectedAudience: "expectedAudience", serverTime: nil)
+        XCTAssertNotNil(error)
+    }
+    
+    func testExpiredExperationTimeReturnsNilWhenUnExpiredServerTimeIsPresent() {
+        let experationTime: String = String(Date().timeIntervalSince1970 - 100)
+        let issueTime: String = String(Date().timeIntervalSince1970)
+        let token: [String: Any] = ["iss": "expectedIssuer" as AnyObject, "aud": ["expectedAudience"], "exp": experationTime, "iat": issueTime]
+        let serverTime = Date().addingTimeInterval(-200)
+        let error: IdTokenValidationError? = validateIdToken(token: token as [String : AnyObject], expectedIssuer: "expectedIssuer", expectedAudience: "expectedAudience", serverTime: serverTime)
+        XCTAssertNil(error)
+    }
+    
+    func testExpiredExperationTimeReturnsErrorWhenServerTimeIsAlsoExpiredPresent() {
+        let experationTime: String = String(Date().timeIntervalSince1970 - 100)
+        let issueTime: String = String(Date().timeIntervalSince1970)
+        let token: [String: Any] = ["iss": "expectedIssuer" as AnyObject, "aud": ["expectedAudience"], "exp": experationTime, "iat": issueTime]
+        let serverTime = Date()
+        let error: IdTokenValidationError? = validateIdToken(token: token as [String : AnyObject], expectedIssuer: "expectedIssuer", expectedAudience: "expectedAudience", serverTime: serverTime)
         XCTAssertNotNil(error)
     }
     
     func testMissingIssueTimeReturnsError() {
         let experationTime: String = String(Date().timeIntervalSince1970 + 100)
         let token: [String: Any] = ["iss": "expectedIssuer" as AnyObject, "aud": ["expectedAudience"], "exp": experationTime]
-        let error: IdTokenValidationError? = validateIdToken(token: token as [String : AnyObject], expectedIssuer: "expectedIssuer", expectedAudience: "expectedAudience")
+        let error: IdTokenValidationError? = validateIdToken(token: token as [String : AnyObject], expectedIssuer: "expectedIssuer", expectedAudience: "expectedAudience", serverTime: nil)
         XCTAssertNotNil(error)
     }
     
@@ -95,7 +113,7 @@ class IdTokenValidatorTest: XCTestCase {
         let experationTime: String = String(Date().timeIntervalSince1970 + 100)
         let issueTime: String = String(Date().timeIntervalSince1970)
         let token: [String: Any] = ["iss": "expectedIssuer" as AnyObject, "aud": ["expectedAudience"], "exp": experationTime, "iat": issueTime]
-        let error: IdTokenValidationError? = validateIdToken(token: token as [String : AnyObject], expectedIssuer: "expectedIssuer", expectedAudience: "expectedAudience")
+        let error: IdTokenValidationError? = validateIdToken(token: token as [String : AnyObject], expectedIssuer: "expectedIssuer", expectedAudience: "expectedAudience", serverTime: nil)
         XCTAssertNil(error)
     }
 }

--- a/TDConnectIosSdkTests/OAuth2ModuleTest.swift
+++ b/TDConnectIosSdkTests/OAuth2ModuleTest.swift
@@ -42,7 +42,7 @@ func setupStubWithNSURLSessionDefaultConfiguration() {
                 return OHHTTPStubsResponse(data:data!, statusCode: 200, headers: ["Content-Type" : "text/json"])
             case "/o/oauth2/token",
                  "/oauth/token":
-                let string = "{\"access_token\":\"NEWLY_REFRESHED_ACCESS_TOKEN\", \"refresh_token\":\"REFRESH_TOKEN\",\"expires_in\":23, \"id_token\":\"NEW_ID_TOKEN\"}"
+                let string = "{\"access_token\":\"NEWLY_REFRESHED_ACCESS_TOKEN\", \"refresh_token\":\"REFRESH_TOKEN\",\"expires_in\":23}"
                 let data = string.data(using: String.Encoding.utf8)
                 return OHHTTPStubsResponse(data:data!, statusCode: 200, headers: ["Content-Type" : "text/json"])
             case "/o/oauth2/revoke",
@@ -298,24 +298,4 @@ class OAuth2ModuleTests: XCTestCase {
         }
         waitForExpectations(timeout: 10, handler: nil)
     }
-    
-    func testExchangeAuthorizationCodeForAccessTokenCallsSaveAccessTokenWithNonNilIdToken() {
-        setupStubWithNSURLSessionDefaultConfiguration()
-        let expectation = self.expectation(description: "AccessRequest");
-        let googleConfig = GoogleConfig(
-            clientId: "xxx.apps.googleusercontent.com",
-            scopes:["https://www.googleapis.com/auth/drive"])
-        
-        let mockedSession = MockOAuth2SessionWithRefreshToken()
-        let oauth2Module = OAuth2Module(config: googleConfig, session: mockedSession)
-        oauth2Module.exchangeAuthorizationCodeForAccessToken (code: "CODE", completionHandler: {(response: AnyObject?, error:NSError?) -> Void in
-            if error != nil {
-                XCTFail("Got error")
-            }
-            XCTAssertTrue(mockedSession.idTokenChanged)
-            expectation.fulfill()
-        })
-        waitForExpectations(timeout: 10, handler: nil)
-    }
-    
 }


### PR DESCRIPTION
`JsonResponseSerializerWithDate` is a hack to get a hold of the `Date` header from the server, as headers are not part of the responseObject given by the `Http` library we are using.

Because of the complications of ID token validation the test for non-nil id token was removed.