### PR TITLE
Support xcframework build.

### DIFF
--- a/TDConnectIosSdk.xcodeproj/project.pbxproj
+++ b/TDConnectIosSdk.xcodeproj/project.pbxproj
@@ -679,6 +679,7 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
 				INFOPLIST_FILE = TDConnectIosSdk/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;


### PR DESCRIPTION
In order to build xcframework, you have to support iphonesimulator build in release.